### PR TITLE
fix: save token, use token from storage, load chats

### DIFF
--- a/src/components/elements/LoginPanel/LoginPanel.tsx
+++ b/src/components/elements/LoginPanel/LoginPanel.tsx
@@ -2,7 +2,7 @@ import "./LoginPanel.style.css";
 import { useState } from "react";
 
 export default function LoginPanel() {
-  const [isChecked, setIsChecked] = useState(false); // запоминать пароль или нет
+  const [isChecked, setIsChecked] = useState(false); // запоминать токен или нет
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
 
@@ -30,10 +30,10 @@ export default function LoginPanel() {
       console.log("JWT токен:", data.access_token);
       console.log("Тип токена", data.token_type);
 
-      if (!isChecked) {
-        localStorage.setItem("access_token", data);
+      if (isChecked) {
+        localStorage.setItem("access_token", data.access_token);
       } else {
-        sessionStorage.setItem("access_token", data);
+        sessionStorage.setItem("access_token", data.access_token);
       }
       window.location.href = "/";
     } catch (error) {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -13,11 +13,11 @@ export default function MainPage() {
   async function getChats() {
     const token = localStorage.getItem("access_token");
     try {
-      const response = await fetch("http://localhost:8091/api/v1/chats/all", {
+      const response = await fetch("http://localhost:8091/api/v1/chats/all/", {
         method: "GET",
         headers: {
           "Content-type": "application/json",
-          Authorization: `Bearier ${token}`,
+          "Authorization": `Bearer ${token}`,
         },
       });
 


### PR DESCRIPTION
с чекбоксом поправил сохранение токена. С ними у меня сейчас вроде всё правильно работает. На главной странице подгружается список чатов. При попытке запроса токен берется из хранилища. С этим надо будет что-то придумать, например: сделать в хранилище переменную для определения - где мы сохранили токен последний раз. 